### PR TITLE
Ysf scoring time

### DIFF
--- a/backend/calculate_streamer_2.js
+++ b/backend/calculate_streamer_2.js
@@ -25,7 +25,7 @@ for (const [k, v] of Object.entries(ATTRIBUTE_POINTS)) {
 // but if input is food, streamer can have either food, or cooking
 const CAT_MAP = {
   "dancing": ["dancing"],
-  "irl": ["irl"],
+  "irl": ["irl", "irl outdoors"],
   "music": ["music & performing arts", "singing", "piano", "music"],
   "sciencetech": ["science & technology", "geoguessr"],
   // HACK: For now, recreated_database.js splites categories in spreadsheet by comma or slash,

--- a/backend/calculate_streamer_2.js
+++ b/backend/calculate_streamer_2.js
@@ -203,10 +203,11 @@ function matchStreamers(prefs, streamers){
   const AttributePoints = {
     age: 1,
     avg_viewers: 1,
-    language: 1,
-    content: 1,
+    language: 1.0,
+    content: 1.0,
     watchtime: 1
   }
+  let totalAttributes = AttributePoints.length;
 
   // array to store the matched streamers
   let matchValues = [];
@@ -224,7 +225,6 @@ function matchStreamers(prefs, streamers){
         scores[streamer.user_name] += AttributePoints.age
       }
     }
-    totalAttributes += 1; 
 
     // check against average viewers preference
     if(streamer.StreamersStat){
@@ -234,7 +234,6 @@ function matchStreamers(prefs, streamers){
           scores[streamer.user_name] += AttributePoints.avg_viewers;
       }
     }
-    totalAttributes += 1;
 
     // check against language preference
     // get the streamers and the user's language arrays
@@ -244,23 +243,16 @@ function matchStreamers(prefs, streamers){
     // add together ALL languages (we don't care about duplicates yet)
     let totalLanguageAttributes = streamersLanguages.length + preferredLanguages.length;
     
-	let totalLangMatch = 0;
-    streamersLanguages.forEach(strLang=>{
-      if(preferredLanguages.includes(strLang)){
-        // if the viewer selected that language, add it as a match
-        // scores[streamer.user_name] += AttributePoints.language;
-		totalLangMatch += 1;
-
-        // and this means there are duplicates in the two datasets, 
-        // we reduce the TOTAL attributes by 1 (removing the duplicate)
-        // totalLanguageAttributes -= 1;
+    let totalLangMatch = 0;
+    prefferedLanguages.forEach(strLang=>{
+      if(streamersLanguage.includes(strLang)){
+        totalLangMatch += 1;
      }
     });
-	// count total match with total input (floating number)
-	if (streamersLanguages.length != 0) {
-	   scores[streamer.user_name] += totalLangMatch * 1.0 / streamersLanguages.length
-	}
-    totalAttributes += 1;
+    // count total match with total input (floating number)
+    if (prefferedLanguages.length != 0) {
+       scores[streamer.user_name] += totalLangMatch * AttributePoints.Language / preferredLanguages.length
+    }
 
     //check against stream content
     let streamersCategories = streamer.Categories.map(cat=>cat.category);
@@ -268,21 +260,15 @@ function matchStreamers(prefs, streamers){
 
     let totalCategoryAttributes = streamersCategories.length + preferredCategories.length;
    
-	let totalCatMatch = 0;
+    let totalCatMatch = 0;
     preferredCategories.forEach(cat=>{
       if(streamersCategories.includes(cat)){
-        // if the streamer's category, increase the score
-        // scores[streamer.user_name] += AttributePoints.content;
-		totalCatMatch += 1;
-
-        // and remove the total by 1 so we dont have duplicate
-        // totalCategoryAttributes -= 1;
+        totalCatMatch += 1;
      }
     });
-	if (streamersCategories.length != 0) {
-		scores[streamer.user_name] += totalCatMatch * 1.0 / streamersCategories.length
-	}
-    totalAttributes += 1;
+    if (streamersCategories.length != 0) {
+      scores[streamer.user_name] += totalCatMatch * AttributePoints.Content / prefferedCategories.length
+    }
 
     // TODO check against watch time (stream start/end time)
       

--- a/backend/calculate_streamer_2.js
+++ b/backend/calculate_streamer_2.js
@@ -369,6 +369,7 @@ function matchStreamers(prefs, streamers){
 }
 
 // sorts the list of streamers by match percentage (highest first)
+// if percentage is the same, get random so we get different streamer
 function orderStreamers(a, b) {
   if (a.match_percent > b.match_percent) {
     return -1;
@@ -377,8 +378,8 @@ function orderStreamers(a, b) {
     return 1;
   }
 
-  if (a.avg_viewer > b.avg_viewer) {
-    return -1;
+  if (Math.random() > 0.5) {
+    return 1;
   }
 
   return -1;

--- a/backend/calculate_streamer_2.js
+++ b/backend/calculate_streamer_2.js
@@ -329,8 +329,6 @@ function matchStreamers(prefs, streamers){
       stats[streamer.id]["content"] = catScore;
     }
 
-    // TODO check against watch time (stream start/end time)
-      
     // finally calculate the match % for our matched streamers and add them to the object we return back to the client
     let similarity = Math.round((scores/TOTAL_ATTRIBUTES)*100);
     matchValues.push({

--- a/backend/test_test.js
+++ b/backend/test_test.js
@@ -1,0 +1,56 @@
+const calculateStreamer = require('./calculate_streamer_2');
+
+console.log("Within range");
+var x = calculateStreamer.countNearScore(1.5, 20, 20, 30, 5);
+console.log(x);
+
+var x = calculateStreamer.countNearScore(1.5, 25, 20, 30, 5);
+console.log(x);
+
+var x = calculateStreamer.countNearScore(1.5, 30, 20, 30, 5);
+console.log(x);
+
+console.log("Close to range");
+var x = calculateStreamer.countNearScore(1.5, 19, 20, 30, 5);
+console.log(1, x);
+
+var x = calculateStreamer.countNearScore(1.5, 32, 20, 30, 5);
+console.log(2, x);
+
+var x = calculateStreamer.countNearScore(1.5, 17, 20, 30, 5);
+console.log(3, x);
+
+var x = calculateStreamer.countNearScore(1.5, 34, 20, 30, 5);
+console.log(4, x);
+
+console.log("Out range");
+var x = calculateStreamer.countNearScore(1.5, 14, 20, 30, 5);
+console.log(x);
+
+var x = calculateStreamer.countNearScore(1.5, 35, 20, 30, 5);
+console.log(x);
+
+console.log("--500 threshold (avg viewer)");
+console.log("Within range");
+var x = calculateStreamer.countNearScore(1.5, 1250, 1000, 1500, 300);
+console.log(x);
+
+console.log("Close to range");
+var x = calculateStreamer.countNearScore(1.5, 900, 1000, 1500, 300);
+console.log(1, x);
+
+var x = calculateStreamer.countNearScore(1.5, 1650, 1000, 1500, 300);
+console.log(2, x);
+
+var x = calculateStreamer.countNearScore(1.5, 800, 1000, 1500, 300);
+console.log(3, x);
+
+var x = calculateStreamer.countNearScore(1.5, 1750, 1000, 1500, 300);
+console.log(4, x);
+
+console.log("Out range");
+var x = calculateStreamer.countNearScore(1.5, 1801, 1000, 1500, 300);
+console.log(x);
+
+var x = calculateStreamer.countNearScore(1.5, 650, 1000, 1500, 300);
+console.log(x);

--- a/db/alter_stream_time.sql
+++ b/db/alter_stream_time.sql
@@ -1,0 +1,3 @@
+alter table streamers_stats
+add column start_stream time with time zone null;
+

--- a/models/streamers_stats.js
+++ b/models/streamers_stats.js
@@ -43,6 +43,10 @@ class StreamersStats extends Sequelize.Model {
     viewer_participation: {
       type: DataTypes.INTEGER,
       allowNull: true
+    },
+    start_stream: {
+      type: DataTypes.TIME,
+      allowNull: true
     }
   }, {
     sequelize,

--- a/public/index.html
+++ b/public/index.html
@@ -317,12 +317,12 @@
 
                 <div class="custom-control custom-switch" style="margin-right:48px;">
                   <input type="checkbox" class="custom-control-input" id="switch_watchtime_weekdays"
-                    onclick="selectSwitch('watchtime','weekdays')">
+                    onclick="selectSwitch('watchtime','weekdays'); captureWatchtimeInput()">
                   <label class="custom-control-label" for="switch_watchtime_weekdays">Weekdays</label>
                 </div>
                 <div class="custom-control custom-switch">
                   <input type="checkbox" class="custom-control-input" id="switch_watchtime_weekends"
-                    onclick="selectSwitch('watchtime','weekends')">
+                    onclick="selectSwitch('watchtime','weekends'); console.log('Weekends not handled yet')">
                   <label class="custom-control-label" for="switch_watchtime_weekends">Weekends</label>
                 </div>
               </div>

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -37,6 +37,9 @@ var SLIDERS ={};
 // since we want to continue to increment/decrement when button is held
 var pressTimer;
 
+// statistic of scoring result
+var ResultStats = {};
+
 // This is called when the page is loaded
 $(() => {
   // setup our bootstrap elements like the sliders
@@ -115,6 +118,9 @@ function setupElements() {
   // disable the continue button by default
   $(`#continue-button`).prop('disabled',true);
   $(`#restart-button`).hide();
+
+  // statistic tooltip hovefr
+  setupStatsTooltipHover();
 }
 
 function setSliderEventHandlers(slider){
@@ -438,13 +444,15 @@ function calculateQuizResult() {
   });
 }
 
-function displayStreamerResults(streamers){
+function displayStreamerResults(results){
+  var streamers = results.result;
+  ResultStats = results.stats;
   streamers.forEach((streamer,index)=>{
     $(`#streamer-${index+1}-user_name`).text(streamer.user_name);
     $(`#streamer-${index+1}-logo`).attr('src',streamer.logo);
     $(`#streamer-${index+1}-match`).text(streamer.match_value);
     $(`#streamer-${index+1}-twitch_link`).attr("href", `https://twitch.tv/${streamer.user_name}`);
-    
+    $($(".streamer-info-container").get(index)).attr("streamer_id", streamer.id);
   });
 }
 
@@ -614,4 +622,42 @@ function captureWatchtimeInput() {
       userOffsetMinute: offset * -1,
     } 
     UsersAnswers['watchtime'] = watchTime;
+}
+
+function setupStatsTooltipHover() {
+  $(".streamer-info-container").tooltip({
+    placement: "right",
+    sanitize: false,
+    html: true,
+    title: function() {
+      var el = $(this);
+      var id = el.attr("streamer_id");
+      if (!(id in ResultStats)) {
+        return ""
+      }
+
+      var tooltip = "<table style='text-align: left'>";
+      for (var k in ResultStats[id]) {
+        var v = ResultStats[id][k];
+        var kColor = statsTooltipColor(v);
+        tooltip += "<tr>";
+          tooltip += "<td>" + k + "</td>";
+          tooltip += "<td>:</td>";
+          tooltip += "<td style='color:" + kColor + "'>" + v + "%</td>";
+        tooltip += "</tr>";
+      }
+      tooltip += "</table>";
+      return tooltip
+    },
+  })
+}
+
+function statsTooltipColor(v) {
+  if (v >= 70) {
+    return "#2ded2d"
+  } else if (v < 30) {
+    return "#e34444"
+  }
+
+  return "white"
 }

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -80,13 +80,15 @@ function setupElements() {
   $('.time').clockTimePicker({
     onClose: function() {
       // adjust time
+      var offset = new Date().getTimezoneOffset();
       let watchTime = {
         watchesWeekend: ($(`#switch_watchtime_weekends`).prop("checked") == true),
         watchesWeekdays:  ($(`#switch_watchtime_weekdays`).prop("checked") == true),
         weekendFrom:  $("#watchtime-weekends-from").val(),
         weekendTo: $("#watchtime-weekends-to").val(),
         weekdayFrom:  $("#watchtime-weekdays-from").val(),
-        weekdayTo: $("#watchtime-weekdays-to").val()
+        weekdayTo: $("#watchtime-weekdays-to").val(),
+        userOffsetMinute: offset * -1,
       } 
       UsersAnswers['watchtime'] = watchTime;
      },

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -79,18 +79,7 @@ function setupElements() {
   
   $('.time').clockTimePicker({
     onClose: function() {
-      // adjust time
-      var offset = new Date().getTimezoneOffset();
-      let watchTime = {
-        watchesWeekend: ($(`#switch_watchtime_weekends`).prop("checked") == true),
-        watchesWeekdays:  ($(`#switch_watchtime_weekdays`).prop("checked") == true),
-        weekendFrom:  $("#watchtime-weekends-from").val(),
-        weekendTo: $("#watchtime-weekends-to").val(),
-        weekdayFrom:  $("#watchtime-weekdays-from").val(),
-        weekdayTo: $("#watchtime-weekdays-to").val(),
-        userOffsetMinute: offset * -1,
-      } 
-      UsersAnswers['watchtime'] = watchTime;
+      captureWatchtimeInput();
      },
      alwaysSelectHoursFirst: true,
      required: true,
@@ -610,4 +599,19 @@ function createNewStreamer(newStreamer) {
       }
     }
   });
+}
+
+function captureWatchtimeInput() {
+    // adjust time
+    var offset = new Date().getTimezoneOffset();
+    let watchTime = {
+      watchesWeekend: ($(`#switch_watchtime_weekends`).prop("checked") == true),
+      watchesWeekdays:  ($(`#switch_watchtime_weekdays`).prop("checked") == true),
+      weekendFrom:  $("#watchtime-weekends-from").val(),
+      weekendTo: $("#watchtime-weekends-to").val(),
+      weekdayFrom:  $("#watchtime-weekdays-from").val(),
+      weekdayTo: $("#watchtime-weekdays-to").val(),
+      userOffsetMinute: offset * -1,
+    } 
+    UsersAnswers['watchtime'] = watchTime;
 }

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -654,9 +654,9 @@ function setupStatsTooltipHover() {
 
 function statsTooltipColor(v) {
   if (v >= 70) {
-    return "#2ded2d"
+    return "#1df51d"
   } else if (v < 30) {
-    return "#e34444"
+    return "#f52525"
   }
 
   return "white"


### PR DESCRIPTION
New
- Scoring by matchtime, with timezone handled.
- Tooltip at frontend result for detailed score
- New DB field is required for stream start time store ` db/alter_stream_time.sql`
- Logarithmic scoring for value that is close to input, configure SCORE_NEAR_THRESHOLD
- Randomized result if total score is the same.

Update
- Weighted question score (see `ATTRIBUTE_POINTS`  backend/calculate_streamer_2.js)
- Fixed preferred language & content scoring.
- Fixed backend ordering of the result.